### PR TITLE
Add "Open Report File" button in disconnect screen

### DIFF
--- a/src/main/java/com/moulberry/moulberrystweaks/Translations.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/Translations.java
@@ -1,0 +1,8 @@
+package com.moulberry.moulberrystweaks;
+
+import net.minecraft.network.chat.Component;
+
+public final class Translations {
+    public static final Component CONFIRM_DISCONNECT = Component.translatable("moulberrystweaks.confirm_disconnect");
+    public static final Component OPEN_REPORT_FILE = Component.translatable("moulberrystweaks.open_disconnect_report_file");
+}

--- a/src/main/java/com/moulberry/moulberrystweaks/config/MoulberrysTweaksConfig.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/config/MoulberrysTweaksConfig.java
@@ -84,6 +84,10 @@ public class MoulberrysTweaksConfig {
         @LatticeWidgetButton
         public boolean debugMovement = false;
 
+        @LatticeOption(title = "moulberrystweaks.config.debugging.add_open_report_file", description = "moulberrystweaks.config.debugging.add_open_report_file.description")
+        @LatticeWidgetButton
+        public boolean addOpenReportFileButton = true;
+
         public static class Inventory {
             @LatticeOption(title = "moulberrystweaks.config.debugging.inventory.item_component_widget", description = "!!.description")
             @LatticeWidgetKeybind
@@ -125,11 +129,11 @@ public class MoulberrysTweaksConfig {
 
         private boolean hideRequiresRelogMessage() {
             return Minecraft.getInstance().player == null ||
-                (this.autoVanishPlayers == MoulberrysTweaks.autoVanishPlayersRegistered &&
-                this.dumpHeldJson == MoulberrysTweaks.dumpHeldJsonRegistered &&
-                this.generateFontWidthTable == MoulberrysTweaks.generateFontWidthTableRegistered &&
-                this.dumpPlayerAttributes == MoulberrysTweaks.dumpPlayerAttributesRegistered &&
-                this.debugRender == MoulberrysTweaks.debugRenderRegistered);
+                    (this.autoVanishPlayers == MoulberrysTweaks.autoVanishPlayersRegistered &&
+                            this.dumpHeldJson == MoulberrysTweaks.dumpHeldJsonRegistered &&
+                            this.generateFontWidthTable == MoulberrysTweaks.generateFontWidthTableRegistered &&
+                            this.dumpPlayerAttributes == MoulberrysTweaks.dumpPlayerAttributesRegistered &&
+                            this.debugRender == MoulberrysTweaks.debugRenderRegistered);
         }
     }
 
@@ -169,7 +173,8 @@ public class MoulberrysTweaksConfig {
         if (!Files.exists(configFolder)) {
             try {
                 Files.createDirectories(configFolder);
-            } catch (IOException ignored) {}
+            } catch (IOException ignored) {
+            }
         }
         this.saveToFolder(configFolder);
     }
@@ -190,7 +195,8 @@ public class MoulberrysTweaksConfig {
                 } catch (IOException e) {
                     MoulberrysTweaks.LOGGER.error("Failed to backup config", e);
                 }
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+            }
         }
 
         this.save(primary);
@@ -206,7 +212,7 @@ public class MoulberrysTweaksConfig {
 
         try {
             Files.writeString(path, serialized, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
-                StandardOpenOption.CREATE, StandardOpenOption.DSYNC);
+                    StandardOpenOption.CREATE, StandardOpenOption.DSYNC);
         } catch (IOException e) {
             MoulberrysTweaks.LOGGER.error("Failed to save config", e);
         }

--- a/src/main/java/com/moulberry/moulberrystweaks/mixin/addopenreportbutton/MixinDisconnectedScreen.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/mixin/addopenreportbutton/MixinDisconnectedScreen.java
@@ -1,0 +1,42 @@
+package com.moulberry.moulberrystweaks.mixin.addopenreportbutton;
+
+import com.moulberry.moulberrystweaks.MoulberrysTweaks;
+import com.moulberry.moulberrystweaks.Translations;
+import net.minecraft.Util;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.DisconnectedScreen;
+import net.minecraft.network.DisconnectionDetails;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DisconnectedScreen.class)
+public class MixinDisconnectedScreen {
+
+    @Shadow
+    @Final
+    private LinearLayout layout;
+
+    @Shadow
+    @Final
+    private DisconnectionDetails details;
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/network/DisconnectionDetails;bugReportLink()Ljava/util/Optional;"), method = "init")
+    private void init(CallbackInfo ci) {
+        if (!MoulberrysTweaks.config.debugging.addOpenReportFileButton) return;
+
+        var button = Button.builder(Translations.OPEN_REPORT_FILE, buttonx -> {
+            if (this.details.report().isPresent()) {
+                Util.getPlatform().openFile(this.details.report().get().toFile());
+            }
+        }).width(200).build();
+
+        if (this.details.report().isPresent()) {
+            this.layout.addChild(button);
+        }
+    }
+}

--- a/src/main/java/com/moulberry/moulberrystweaks/mixin/confirmdisconnect/MixinPauseScreen.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/mixin/confirmdisconnect/MixinPauseScreen.java
@@ -1,6 +1,7 @@
 package com.moulberry.moulberrystweaks.mixin.confirmdisconnect;
 
 import com.moulberry.moulberrystweaks.MoulberrysTweaks;
+import com.moulberry.moulberrystweaks.Translations;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.client.gui.screens.Screen;
@@ -31,7 +32,7 @@ public class MixinPauseScreen extends Screen {
     public void onDisconnect(CallbackInfo ci) {
         if (MoulberrysTweaks.config.gameplay.confirmDisconnect && this.disconnectButton != null && !this.confirmingDisconnect && !this.minecraft.isLocalServer()) {
             this.disconnectButton.active = true;
-            this.disconnectButton.setMessage(Component.translatable("moulberrystweaks.confirm_disconnect"));
+            this.disconnectButton.setMessage(Translations.CONFIRM_DISCONNECT);
             this.confirmingDisconnect = true;
             ci.cancel();
         }

--- a/src/main/resources/assets/moulberrystweaks/lang/en_us.json
+++ b/src/main/resources/assets/moulberrystweaks/lang/en_us.json
@@ -2,7 +2,6 @@
   "moulberrystweaks.keybind": "Moulberry's Tweaks",
   "moulberrystweaks.keybind.view_components": "View Item Components",
   "moulberrystweaks.keybind.view_packets": "View Inventory Packets",
-
   "moulberrystweaks.config.gameplay": "Gameplay",
   "moulberrystweaks.config.gameplay.confirm_disconnect": "Confirm Disconnect",
   "moulberrystweaks.config.gameplay.confirm_disconnect.description": "Adds a confirmation when disconnecting from a server to avoid accidental disconnects",
@@ -10,19 +9,16 @@
   "moulberrystweaks.config.gameplay.correct_attack_indicator.description": "The attack indicator bar is inaccurate. It resets internally whenever you swing your arms, but will still visually show a full bar. This feature makes the attack indicator visually show the correct value",
   "moulberrystweaks.config.gameplay.prevent_server_closing_pause_screen": "Prevent Server Closing Pause Screen",
   "moulberrystweaks.config.gameplay.prevent_server_closing_pause_screen.description": "Prevents the server from closing your pause screen and other sub-screens",
-
   "moulberrystweaks.config.loading_overlay": "Loading Overlay",
   "moulberrystweaks.config.loading_overlay.fast": "Fast Loading Overlay",
   "moulberrystweaks.config.loading_overlay.fast.description": "Speeds up the resource loading overlay by removing the fade out animation",
   "moulberrystweaks.config.loading_overlay.transparent": "Transparent Loading Overlay",
   "moulberrystweaks.config.loading_overlay.transparent.description": "Removes the background from the resource loading overlay",
-
   "moulberrystweaks.config.resource_pack": "Resource Pack",
   "moulberrystweaks.config.resource_pack.automatic_pack_reload": "Automatic Pack Reload",
   "moulberrystweaks.config.resource_pack.automatic_pack_reload.description": "Automatically reloads resourcepacks when a file in the folder is changed",
   "moulberrystweaks.config.resource_pack.disable_warnings": "Disable Warnings",
   "moulberrystweaks.config.resource_pack.disable_warnings.description": "Disables the warning screen when toggling resourcepacks with the wrong version",
-
   "moulberrystweaks.config.debugging": "Debugging",
   "moulberrystweaks.config.debugging.log_packet_exceptions": "Log Packet Exceptions",
   "moulberrystweaks.config.debugging.log_packet_exceptions.description": "Prints the stacktrace of a packet exception, useful for debugging",
@@ -35,7 +31,8 @@
   "moulberrystweaks.config.debugging.inventory.packet_debug_widget.description": "Keybind to open a widget showing incoming and outgoing inventory packets. Useful for server developers",
   "moulberrystweaks.config.debugging.debug_movement": "Send Debug Movement",
   "moulberrystweaks.config.debugging.debug_movement.description": "Sends debug movement data to the server every tick. Useful for anticheat developers (moulberrystweaks:debug_movement_data)",
-
+  "moulberrystweaks.config.debugging.add_open_report_file": "Add \"Open Report File\" Button",
+  "moulberrystweaks.config.debugging.add_open_report_file.description": "Adds an \"Open Report File\" button to the disconnect screen that directly opens the report file",
   "moulberrystweaks.config.commands": "Commands",
   "moulberrystweaks.config.commands.auto_vanish_players": "Auto Vanish Players",
   "moulberrystweaks.config.commands.auto_vanish_players.description": "Command to automatically vanish players that are nearby. Useful for parkour servers so you can see where to go",
@@ -47,6 +44,6 @@
   "moulberrystweaks.config.commands.dump_player_attributes.description": "Dumps the entity attributes of the player entity. Useful for developers",
   "moulberrystweaks.config.commands.debug_render": "Debug Render",
   "moulberrystweaks.config.commands.debug_render.description": "Allows hiding/clearing debug renders sent by the server using the debug_render protocol. Useful for developers",
-
-  "moulberrystweaks.confirm_disconnect": "Confirm Disconnect"
+  "moulberrystweaks.confirm_disconnect": "Confirm Disconnect",
+  "moulberrystweaks.open_disconnect_report_file": "Open Report File"
 }

--- a/src/main/resources/moulberrystweaks.mixins.json
+++ b/src/main/resources/moulberrystweaks.mixins.json
@@ -22,6 +22,7 @@
     "debugmovement.MixinLivingEntity",
     "debugshape.MixinDebugScreenOverlay",
     "debugshape.MixinLevelRenderer",
+    "addopenreportbutton.MixinDisconnectedScreen",
     "inventorywidgets.MixinAbstractContainerScreen",
     "inventorywidgets.MixinConnection",
     "packetexceptionlogging.MixinConnection",


### PR DESCRIPTION
Adds an "Open Report File" button to the disconnect screen (and config option for it) because its annoying opening the folder and finding the latest file amongst 10000 disconnect report files


https://github.com/user-attachments/assets/6014d3af-1a44-4208-86f9-afeea4bddce8

