### PR TITLE
Fix widget rendering issues

### DIFF
--- a/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractContainerScreen.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractContainerScreen.java
@@ -72,7 +72,6 @@ public class MixinAbstractContainerScreen {
             if (removed) {
                 ActiveWidgets.logPackets = false;
             } else {
-                System.out.println("Adding packet viewer");
                 ActiveWidgets.activeWidgets.add(new PacketViewerWidget());
                 ActiveWidgets.logPackets = true;
             }

--- a/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractContainerScreen.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractContainerScreen.java
@@ -7,6 +7,7 @@ import com.moulberry.moulberrystweaks.widget.FloatingTextWidget;
 import com.moulberry.moulberrystweaks.widget.PacketViewerWidget;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.world.inventory.Slot;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -71,6 +72,7 @@ public class MixinAbstractContainerScreen {
             if (removed) {
                 ActiveWidgets.logPackets = false;
             } else {
+                System.out.println("Adding packet viewer");
                 ActiveWidgets.activeWidgets.add(new PacketViewerWidget());
                 ActiveWidgets.logPackets = true;
             }
@@ -116,5 +118,4 @@ public class MixinAbstractContainerScreen {
             widget.render(guiGraphics, mouseX, mouseY);
         }
     }
-
 }

--- a/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractRecipeBookScreen.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/mixin/inventorywidgets/MixinAbstractRecipeBookScreen.java
@@ -1,0 +1,22 @@
+package com.moulberry.moulberrystweaks.mixin.inventorywidgets;
+
+import com.moulberry.moulberrystweaks.widget.ActiveWidgets;
+import com.moulberry.moulberrystweaks.widget.FloatingTextWidget;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractRecipeBookScreen.class)
+public class MixinAbstractRecipeBookScreen {
+    @Inject(method = "render", at = @At("RETURN"))
+    public void afterRender(GuiGraphics guiGraphics, int mouseX, int mouseY, float f, CallbackInfo ci) {
+        // Render in reverse order so that the first widget renders on top
+        for (int i = ActiveWidgets.activeWidgets.size()-1; i >= 0; i--) {
+            FloatingTextWidget widget = ActiveWidgets.activeWidgets.get(i);
+            widget.render(guiGraphics, mouseX, mouseY);
+        }
+    }
+}

--- a/src/main/java/com/moulberry/moulberrystweaks/widget/FloatingTextWidget.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/widget/FloatingTextWidget.java
@@ -225,6 +225,9 @@ public class FloatingTextWidget {
                 this.updateScrollOffset(false);
             }
 
+            guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, ResourceLocation.fromNamespaceAndPath("minecraft", "popup/background"),
+                    this.windowX, this.windowY, this.windowWidth, this.windowHeight);
+
             guiGraphics.enableScissor(this.windowX + 6, this.windowY + 6, this.windowX+this.windowWidth - 6, this.windowY+this.windowHeight - 6);
 
             int y = this.windowY + PADDING - (int) this.scrollOffset;
@@ -257,9 +260,6 @@ public class FloatingTextWidget {
             }
 
             guiGraphics.disableScissor();
-
-            guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, ResourceLocation.fromNamespaceAndPath("minecraft", "popup/background"),
-                this.windowX, this.windowY, this.windowWidth, this.windowHeight);
 
             guiGraphics.drawString(this.font, this.name, this.windowX+10, this.windowY-this.font.lineHeight, -1);
 

--- a/src/main/java/com/moulberry/moulberrystweaks/widget/PacketViewerWidget.java
+++ b/src/main/java/com/moulberry/moulberrystweaks/widget/PacketViewerWidget.java
@@ -117,7 +117,7 @@ public class PacketViewerWidget extends FloatingTextWidget {
         } else {
             long currentTime = System.currentTimeMillis();
             if (currentTime - lastPacketTime > 500) {
-                lines.add(0, Component.literal("...").withStyle(ChatFormatting.GRAY));
+                lines.addFirst(Component.literal("...").withStyle(ChatFormatting.GRAY));
             }
             lastPacketTime = currentTime;
         }

--- a/src/main/resources/moulberrystweaks.mixins.json
+++ b/src/main/resources/moulberrystweaks.mixins.json
@@ -8,6 +8,7 @@
   "client": [
     "MixinLoadingOverlay",
     "MixinTransferableSelectionListPackEntry",
+    "addopenreportbutton.MixinDisconnectedScreen",
     "attackindicator.MixinGui",
     "attackindicator.MixinLocalPlayer",
     "attackindicator.MixinPlayer",
@@ -22,8 +23,8 @@
     "debugmovement.MixinLivingEntity",
     "debugshape.MixinDebugScreenOverlay",
     "debugshape.MixinLevelRenderer",
-    "addopenreportbutton.MixinDisconnectedScreen",
     "inventorywidgets.MixinAbstractContainerScreen",
+    "inventorywidgets.MixinAbstractRecipeBookScreen",
     "inventorywidgets.MixinConnection",
     "latency.MixinConnection",
     "packetexceptionlogging.MixinConnection",


### PR DESCRIPTION
Widgets were not displaying in screens that extend `AbstractRecipeBookScreen` (like the player's inventory), and when a widget was present, they were rendering in the wrong z-order.

Issue occurred in 1.21.8
my local fabric versions:
* fabric-loader: 0.17.2-1.21.8
* fabric-api: 0.132.0+1.21.8